### PR TITLE
chore(renovate): disable Renovate to stop monthly Actions usage

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "enabled": false,
   "extends": [
     "config:base",
     ":semanticCommits",


### PR DESCRIPTION
## Summary
- `.github/renovate.json` に `"enabled": false` を追加してRenovate全停止
- Renovate由来のPR → CI連鎖でActionsを毎月消費していたのを止めるため

## Test plan
- [ ] マージ後、Renovateが新規PRを作らないことを確認（次の実行サイクルで）
- [ ] 必要になったら `"enabled": false` を消すか `true` にすれば再開可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)